### PR TITLE
Added support for using actual sunrise and -set times

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@
 
 ### parameters
 
-key        | required | description
------------|----------|----------------------------------------------------
-`timezone` | no       | *Name of the timezone, like `America/Los_Angeles`. See http://momentjs.com/timezone/ for possible values. Defaults to local time.*
-`info`     | no       | *Free textual value to show within clock. Special values are: `timezone`, `date`, `time`.
-`sunRise`  | no       | *Local time when sun rises (used for day/night indicator). Defaults to `6:00`.*
-`sunSet`   | no       | *Local time when sun sets (used for day/night indicator). Defaults to `18:00`.*
+key        | required                    | description
+-----------|-----------------------------|----------------------------------------------------
+`timezone` | no *(yes if `city` is set)* | *Name of the timezone, like `America/Los_Angeles`. See http://momentjs.com/timezone/ for possible values. Defaults to local time.*
+`city`     | no                          | *Name of city used to fetch the local sunrise and -set info. By default, uses the city name from the timezone info, if available.*
+`info`     | no                          | *Free textual value to show within clock. Special values are: `timezone`, `date`, `sun`, `time`.*
 
 ### usage
 
@@ -29,13 +28,17 @@ key        | required | description
   type: 'time.clock',
   timezone: 'America/Los_Angeles',
   info: 'timezone',
-  sunRise: '6:30',
-  sunSet: '17:43',
   columns: 1, rows: 1, x: 1, y: 0
 },
 {
   type: 'time.clock',
-  info: 'Time is money!',
+  timezone: 'Europe/Helsinki',
+  city: 'Utsjoki',
   columns: 1, rows: 1, x: 2, y: 0
+},
+{
+  type: 'time.clock',
+  info: 'Time is money!',
+  columns: 1, rows: 1, x: 3, y: 0
 }
 ```

--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/client');

--- a/package.json
+++ b/package.json
@@ -15,10 +15,17 @@
   },
   "homepage": "https://github.com/plouc/mozaik-ext-time",
   "dependencies": {
+    "bluebird": "^2.9.13",
+    "chalk": "^1.0.0",
     "d3": "^3.5.5",
-    "react-classset": "0.0.2",
+    "memory-cache": "^0.1.1",
     "moment": "^2.9.0",
-    "moment-timezone": "^0.3.0"
+    "moment-timezone": "^0.3.0",
+    "react-classset": "0.0.2",
+    "string-format": "^0.5.0",
+    "string-template": "^0.2.0",
+    "superagent": "^0.21.0",
+    "superagent-bluebird-promise": "^1.1.0"
   },
   "main": "./components.js",
   "devDependencies": {

--- a/src/__tests__/Clock-test.js
+++ b/src/__tests__/Clock-test.js
@@ -4,6 +4,10 @@ jest.dontMock('d3/d3');
 jest.dontMock('moment');
 jest.dontMock('moment-timezone');
 
+jest.setMock('mozaik/browser', {
+    Mixin: { ApiConsumer: null }
+});
+
 var React, TestUtils, Clock, clock;
 
 describe('Time — Clock', function () {

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,43 @@
+var chalk   = require('chalk');
+var request = require('superagent');
+var Promise = require('bluebird');
+var cache   = require('memory-cache');
+var format  = require('string-template');
+require('superagent-bluebird-promise');
+
+/**
+ * @param {Mozaik} context
+ */
+var client = function (context) {
+    return {
+        // Fetch sunset and coordinate info
+        info: function (params) {
+            // If city info is not provided, no backend info is needed
+            if (!params.city || params.city.length === 0) {
+                return Promise.resolve();
+            }
+
+            var cacheKey = format('time.info.{timezone}.{city}', params);
+            if (cache.get(cacheKey) !== null) {
+                return new Promise(function (resolve) {
+                    resolve(cache.get(cacheKey));
+                });
+            }
+
+            return request.get('http://api.openweathermap.org/data/2.5/weather?q=' + params.city)
+                .promise()
+                .then(function (res) {
+                    // Check if response seem valid
+                    if (!res.body.sys) {
+                        context.logger.error(chalk.red('Failed to find location info for', params.city));
+                        return res.body
+                    }
+                    // Cache the response for 12h hours
+                    cache.put(cacheKey, res.body, 43200000);
+                    return res.body;
+                });
+        }
+    };
+};
+
+module.exports = client;


### PR DESCRIPTION
- Using backend client to fetch sun info from openweathermap.org
- Removed fixed props: sunRise, setSet
- Added new prop: city for getting the local sun info
- Added sun info in info fields

The provided info could be now utilized to create additional widgets, but it's a worth of separate PRs.
