### PR TITLE
Added support for showing the widget title

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 key        | required | description
 -----------|----------|----------------------------------------------------
+`title`    | no       | *Title of the widget*
 `timezone` | no       | *Name of the timezone, like `America/Los_Angeles`. See http://momentjs.com/timezone/ for possible values. Defaults to local time.*
 `info`     | no       | *Free textual value to show within clock. Special values are: `timezone`, `date`, `time`.
 `sunRise`  | no       | *Local time when sun rises (used for day/night indicator). Defaults to `6:00`.*

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -44,6 +44,17 @@ var Clock = React.createClass({
             transform: `rotate(${ secondsScale(this.state.seconds) }deg)`
         };
 
+        // Show title only when set
+        var title;
+        if (this.props.title) {
+            title = (
+                <div className="widget__header">
+                    {this.props.title}
+                    <i className="fa fa-clock-o" />
+                </div>
+            );
+        }
+
         // Day/night indicator
         var sunRise = this.state.moment.clone().hours(6).minutes(0);
         var sunSet  = this.state.moment.clone().hours(18).minutes(0);
@@ -76,13 +87,16 @@ var Clock = React.createClass({
 
         return (
             <div>
-                <div className="time__clock__outer-circle" />
-                <span className={timeIndicatorClasses}></span>
-                <span className="time__clock__info">{info}</span>
-                <div className="time__clock__hand time__clock__hand--seconds" style={secondsStyle} />
-                <div className="time__clock__hand time__clock__hand--minutes" style={minutesStyle} />
-                <div className="time__clock__hand time__clock__hand--hours"   style={hoursStyle} />
-                <div className="time__clock__inner-circle" />
+                {title}
+                <div className="widget__body">
+                    <div className="time__clock__outer-circle" />
+                    <span className={timeIndicatorClasses}></span>
+                    <span className="time__clock__info">{info}</span>
+                    <div className="time__clock__hand time__clock__hand--seconds" style={secondsStyle} />
+                    <div className="time__clock__hand time__clock__hand--minutes" style={minutesStyle} />
+                    <div className="time__clock__hand time__clock__hand--hours"   style={hoursStyle} />
+                    <div className="time__clock__inner-circle" />
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
For the sake of consistency, add support for showing optional widget title. If title param is not set, no title bar nor value is shown.
