### PR TITLE
Add support for 24hour formatting of the time

### DIFF
--- a/src/components/Clock.js
+++ b/src/components/Clock.js
@@ -171,6 +171,7 @@ export default class Clock extends Component {
                 : this.props.timezone,
             date: this.state.moment.format('ll'),
             time: this.state.moment.format('LT'),
+            time24h: this.state.moment.format('HH:mm'),
         }
         const info = infoFields[this.props.info] || this.props.info
 


### PR DESCRIPTION
In europe it is common to use 24hour formatting instead of the American/UK style of am/pm.